### PR TITLE
OPENEUROPA-3239: Don't redirect to <front> when corporate contact form is submitted.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.7.8",
+        "drupal/core": "^8.8",
         "drupal/contact_storage": "1.0.0",
         "drupal/contact_storage_export": "^1.13",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",

--- a/src/Form/ContactMessageForm.php
+++ b/src/Form/ContactMessageForm.php
@@ -6,6 +6,7 @@ namespace Drupal\oe_contact_forms\Form;
 
 use Drupal\contact\MessageForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * Form controller for contact message forms.
@@ -70,12 +71,6 @@ class ContactMessageForm extends MessageForm {
     /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $message->getContactForm();
 
-    // Redirect back to same page if redirect value is not set.
-    if (!$contact_form->getRedirectPath()) {
-      $contact_form->setRedirectPath(\Drupal::service('path.current')->getPath());
-      $contact_form->save();
-    }
-
     // If the form is configured to include all the fields in the auto-reply,
     // set the values after the auto-reply body,
     // so they get included in the email as well.
@@ -117,6 +112,11 @@ class ContactMessageForm extends MessageForm {
     // The values of the submitted fields.
     $full_view = $this->entityTypeManager->getViewBuilder('contact_message')->view($message, 'full');
     $this->messenger()->addMessage($full_view);
+
+    // Redirect back to same page if redirect value is not set.
+    if (!$contact_form->getRedirectPath()) {
+      $form_state->setRedirectUrl(Url::fromRoute('<current>'));
+    }
   }
 
 }

--- a/src/Form/ContactMessageForm.php
+++ b/src/Form/ContactMessageForm.php
@@ -70,6 +70,12 @@ class ContactMessageForm extends MessageForm {
     /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $message->getContactForm();
 
+    // Redirect back to same page if redirect value is not set.
+    if (!$contact_form->getRedirectPath()) {
+      $contact_form->setRedirectPath(\Drupal::service('path.current')->getPath());
+      $contact_form->save();
+    }
+
     // If the form is configured to include all the fields in the auto-reply,
     // set the values after the auto-reply body,
     // so they get included in the email as well.

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -36,12 +36,6 @@ class MessageFormTest extends WebDriverTestBase {
   protected function setUp() {
     parent::setUp();
 
-    // In Drupal 8.8, paths have been moved to an entity type.
-    // @todo remove this when the component will depend on 8.8.
-    if (version_compare(\Drupal::VERSION, '8.8.0', '>=')) {
-      $this->container->get('module_installer')->install(['path_alias']);
-    }
-
     // Create and login test user.
     /** @var \Drupal\user\UserInterface $test_user */
     $testuser = $this->drupalCreateUser([


### PR DESCRIPTION
## OPENEUROPA-3239

### Description

Don't redirect to <front> when corporate contact form is submitted.

### Change log

- Added:
  - extended ContactMessageForm with a redirect check
  - adopted a test in CorporateContactFormTest to make sure there is no redirection anymore
  

