### PR TITLE
OPENEUROPA-3045: Contact form blocks

### DIFF
--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\contact\Entity\ContactForm;
@@ -199,6 +200,27 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
   }
 
   $form['#entity_builders'][] = '_oe_contact_forms_contact_form_builder';
+}
+
+/**
+ * Clear block cached definitions.
+ */
+function _oe_contact_forms_clear_block_cached_definitions(): void {
+  \Drupal::service('plugin.manager.block')->clearCachedDefinitions();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function oe_contact_forms_contact_form_presave(EntityInterface $entity) {
+  _oe_contact_forms_clear_block_cached_definitions();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function oe_contact_forms_contact_form_delete(EntityInterface $entity) {
+  _oe_contact_forms_clear_block_cached_definitions();
 }
 
 /**

--- a/src/Plugin/Block/CorporateFormBlock.php
+++ b/src/Plugin/Block/CorporateFormBlock.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_contact_forms\Plugin\Block;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\contact\Entity\ContactForm;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Render\RendererInterface;
+
+/**
+ * Provides a block that renders a corporate form.
+ *
+ * @Block(
+ *   id = "oe_contact_forms_corporate_block",
+ *   admin_label = @Translation("Corporate form"),
+ *   category = @Translation("Corporate forms"),
+ *   deriver = "Drupal\oe_contact_forms\Plugin\Derivative\CorporateFormBlock",
+ * )
+ */
+class CorporateFormBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The EntityFormBuilder.
+   *
+   * @var \Drupal\Core\Entity\EntityFormBuilder
+   */
+  protected $entityFormBuilder;
+
+  /**
+   * The Renderer.
+   *
+   * @var \Drupal\Core\Render\Renderer
+   */
+  protected $renderer;
+
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new CorporateFormBlock.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFormBuilderInterface $entity_form_builder
+   *   The entity form builder.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer.
+   */
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entityTypeManager, EntityFormBuilderInterface $entity_form_builder, RendererInterface $renderer) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityFormBuilder = $entity_form_builder;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity.form_builder'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockAccess(AccountInterface $account) {
+    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    $contact_form = $this->getContactForm();
+
+    if (!$contact_form) {
+      return AccessResult::forbidden();
+    }
+
+    return $contact_form->access('access corporate contact form', $account, TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    $contact_form = $this->getContactForm();
+    if (!$contact_form) {
+      return [];
+    }
+    $builder = $this->entityTypeManager->getViewBuilder('contact_form');
+    return $builder->view($contact_form);
+  }
+
+  /**
+   * Returns the derived contact form.
+   *
+   * @return \Drupal\contact\Entity\ContactForm|null
+   *   The contact form entity.
+   */
+  protected function getContactForm(): ?ContactForm {
+    $uuid = $this->getDerivativeId();
+    $contact_form = $this->entityTypeManager->getStorage('contact_form')->loadByProperties(['uuid' => $uuid]);
+    if (!$contact_form) {
+      // Normally, this should not happen but in case the entity has been
+      // deleted.
+      return NULL;
+    }
+
+    return reset($contact_form);
+  }
+
+}

--- a/src/Plugin/Derivative/CorporateFormBlock.php
+++ b/src/Plugin/Derivative/CorporateFormBlock.php
@@ -22,7 +22,7 @@ class CorporateFormBlock extends DeriverBase implements ContainerDeriverInterfac
   protected $entityTypeManager;
 
   /**
-   * LinkListBlock constructor.
+   * CorporateFormBlock constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
@@ -46,20 +46,19 @@ class CorporateFormBlock extends DeriverBase implements ContainerDeriverInterfac
   public function getDerivativeDefinitions($base_plugin_definition) {
     /** @var \Drupal\contact\ContactFormInterface[] $contact_forms */
     $contact_forms = $this->entityTypeManager->getStorage('contact_form')->loadMultiple();
+    $this->derivatives = [];
+
     foreach ($contact_forms as $key => $contact_form) {
       $expose_as_block = $contact_form->getThirdPartySetting('oe_contact_forms', 'expose_as_block', FALSE);
-      $is_corporate_form = $contact_form->getThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
-
       // Only expose corporate forms configured as block.
-      if ($expose_as_block && $is_corporate_form) {
+      if ($expose_as_block) {
         $this->derivatives[$contact_form->uuid()] = $base_plugin_definition;
         $this->derivatives[$contact_form->uuid()]['admin_label'] = $contact_form->label();
         $this->derivatives[$contact_form->uuid()]['config_dependencies']['config'] = [$contact_form->getConfigDependencyName()];
       }
-
     }
 
-    return $this->derivatives;
+    return parent::getDerivativeDefinitions($base_plugin_definition);
   }
 
 }

--- a/src/Plugin/Derivative/CorporateFormBlock.php
+++ b/src/Plugin/Derivative/CorporateFormBlock.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_contact_forms\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Deriver class for corporate contact form blocks.
+ */
+class CorporateFormBlock extends DeriverBase implements ContainerDeriverInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * LinkListBlock constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    /** @var \Drupal\contact\ContactFormInterface[] $contact_forms */
+    $contact_forms = $this->entityTypeManager->getStorage('contact_form')->loadMultiple();
+    foreach ($contact_forms as $key => $contact_form) {
+      $expose_as_block = $contact_form->getThirdPartySetting('oe_contact_forms', 'expose_as_block', FALSE);
+      $is_corporate_form = $contact_form->getThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
+
+      // Only expose corporate forms configured as block.
+      if ($expose_as_block && $is_corporate_form) {
+        $this->derivatives[$contact_form->uuid()] = $base_plugin_definition;
+        $this->derivatives[$contact_form->uuid()]['admin_label'] = $contact_form->label();
+        $this->derivatives[$contact_form->uuid()]['config_dependencies']['config'] = [$contact_form->getConfigDependencyName()];
+      }
+
+    }
+
+    return $this->derivatives;
+  }
+
+}

--- a/tests/src/Kernel/BlocksTest.php
+++ b/tests/src/Kernel/BlocksTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_contact_forms\Kernel;
+
+use Drupal\contact\Entity\ContactForm;
+
+/**
+ * Tests contact form block derivatives.
+ */
+class BlocksTest extends ContactFormTestBase {
+
+  /**
+   * Tests that we have a block derivative for exposed contact forms.
+   */
+  public function testBlockDerivatives(): void {
+    /** @var \Drupal\Core\Block\BlockManagerInterface $block_manager */
+    $block_manager = $this->container->get('plugin.manager.block');
+
+    $contact_form = ContactForm::create(['id' => 'oe_contact_form']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', TRUE);
+    $topic_label = 'Topic label';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topic_label', $topic_label);
+    $header = 'this is a test header';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $header);
+    $privacy_text = 'this is a test privacy policy';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_text);
+    $topics = [['topic_name' => 'Topic name', 'topic_email_address' => 'topic@emailaddress.com']];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topics', $topics);
+    $contact_form->save();
+    $plugin_id = 'oe_contact_forms_corporate_block:' . $contact_form->uuid();
+
+    // Assert the block was created.
+    $this->assertTrue($block_manager->hasDefinition($plugin_id));
+
+    /** @var \Drupal\oe_contact_forms\Plugin\Block\CorporateFormBlock $plugin */
+    $plugin = $block_manager->createInstance($plugin_id);
+    $build = $plugin->build();
+
+    // Assert we have correct build.
+    $this->assertEqual($build['header']['#markup'], $header);
+    $this->assertEqual($build['privacy_policy']['#description'], $privacy_text);
+    $this->assertEqual($build['oe_topic']['widget']['#title'], $topic_label);
+
+    // Remove from derivatives.
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', FALSE);
+    $contact_form->save();
+
+    // Assert the block was removed.
+    $this->assertFalse($block_manager->hasDefinition($plugin_id));
+
+    $contact_form = ContactForm::create(['id' => 'oe_contact_form_no_block']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', FALSE);
+    $contact_form->save();
+    $plugin_id = 'oe_contact_forms_corporate_block:' . $contact_form->uuid();
+
+    // Assert the block was not created.
+    $this->assertFalse($block_manager->hasDefinition($plugin_id));
+
+    // Now expose the block to pick up the change.
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', TRUE);
+    $contact_form->save();
+
+    // Assert the block was created.
+    $this->assertTrue($block_manager->hasDefinition($plugin_id));
+
+    // Now delete the block content entity.
+    $contact_form->delete();
+
+    // Assert the block was removed.
+    $this->assertFalse($block_manager->hasDefinition($plugin_id));
+
+    $contact_form = ContactForm::create(['id' => 'default_contact_form']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
+    $contact_form->save();
+    $plugin_id = 'oe_contact_forms_corporate_block:' . $contact_form->uuid();
+
+    // Assert the block was not created.
+    $this->assertFalse($block_manager->hasDefinition($plugin_id));
+  }
+
+}

--- a/tests/src/Kernel/ContactFormTestBase.php
+++ b/tests/src/Kernel/ContactFormTestBase.php
@@ -15,6 +15,7 @@ class ContactFormTestBase extends RdfKernelTestBase {
    * {@inheritdoc}
    */
   public static $modules = [
+    'path',
     'options',
     'telephone',
     'contact',
@@ -28,6 +29,7 @@ class ContactFormTestBase extends RdfKernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->installEntitySchema('path_alias');
     $this->installEntitySchema('contact_message');
   }
 


### PR DESCRIPTION
## OPENEUROPA-3045

### Description

Expose corporate contact forms as blocks.

### Change log

- Added:
   - block cache clearing on contact form submit
   - BlockBase and DeriverBase
   - Derivative test, block access test, block form functional test
- Changed: CorporateContactFormTest to SettingsFormTest


