### PR TITLE
OPENEUROPA-3293: Change privacy policy behaviour

### DIFF
--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -199,6 +199,31 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
   }
 
   $form['#entity_builders'][] = '_oe_contact_forms_contact_form_builder';
+  $form['actions']['submit']['#submit'][] = '_oe_contact_forms_contact_form_submit';
+}
+
+/**
+ * Submit callback for the corporate contact form to clear block definitions.
+ *
+ * @param array $form
+ *   The form.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function _oe_contact_forms_contact_form_submit(array $form, FormStateInterface $form_state): void {
+  /** @var \Drupal\contact\ContactFormInterface $contact_form */
+  $contact_form = $form_state->getFormObject()->getEntity();
+  /** @var \Drupal\Core\Block\BlockManagerInterface $block_manager */
+  $block_manager = \Drupal::service('plugin.manager.block');
+  $plugin_id = 'oe_contact_forms_corporate_block:' . $contact_form->uuid();
+  $expose_as_block = (boolean) $contact_form->getThirdPartySetting('oe_contact_forms', 'expose_as_block', TRUE);
+
+  // Only flush block definitions if contact form is/was exposed as block.
+  if (!$block_manager->hasDefinition($plugin_id) && !$expose_as_block) {
+    return;
+  }
+
+  $block_manager->clearCachedDefinitions();
 }
 
 /**

--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -158,10 +158,10 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
       '#default_value' => $contact_form->getThirdPartySetting('oe_contact_forms', 'header', ''),
     ];
     $form['corporate_fields']['privacy_policy'] = [
-      '#type' => 'textarea',
-      '#title' => t('Privacy policy'),
+      '#type' => 'url',
+      '#title' => t('Privacy policy link'),
       '#required' => TRUE,
-      '#description' => t("Please specify a privacy policy message to display on the form."),
+      '#description' => t("Link to form privacy policy/data protection page."),
       '#default_value' => $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', ''),
     ];
     $form['corporate_fields']['includes_fields_in_auto_reply'] = [

--- a/src/Form/ContactMessageForm.php
+++ b/src/Form/ContactMessageForm.php
@@ -26,18 +26,16 @@ class ContactMessageForm extends MessageForm {
     $contact_form = $message->getContactForm();
 
     $header = $contact_form->getThirdPartySetting('oe_contact_forms', 'header', FALSE);
-
+    $privacy_link = $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', FALSE);
     if (!empty($header)) {
       $form['header'] = [
         '#markup' => $header,
       ];
     }
-
     // Checkbox to accept privacy policy configured in the ContactForm.
     $form['privacy_policy'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('I accept privacy policy'),
-      '#description' => $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy'),
+      '#title' => $this->t('Check to accept our <a href="@link" target="_blank">privacy policy</a>', ['@link' => $privacy_link]),
       '#required' => TRUE,
     ];
 
@@ -103,12 +101,6 @@ class ContactMessageForm extends MessageForm {
     parent::save($form, $form_state);
 
     // Apart from the confirmation message also include the following.
-    // Privacy notice.
-    $privacy_policy = $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', '');
-
-    if (!empty($privacy_policy)) {
-      $this->messenger()->addMessage($privacy_policy);
-    }
     // The values of the submitted fields.
     $full_view = $this->entityTypeManager->getViewBuilder('contact_message')->view($message, 'full');
     $this->messenger()->addMessage($full_view);

--- a/src/Plugin/Block/CorporateFormBlock.php
+++ b/src/Plugin/Block/CorporateFormBlock.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_contact_forms\Plugin\Block;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\contact\Entity\ContactForm;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\Core\Render\RendererInterface;
+
+/**
+ * Provides a block that renders a corporate form.
+ *
+ * @Block(
+ *   id = "oe_contact_forms_corporate_block",
+ *   admin_label = @Translation("Corporate form"),
+ *   category = @Translation("Corporate forms"),
+ *   deriver = "Drupal\oe_contact_forms\Plugin\Derivative\CorporateFormBlock",
+ * )
+ */
+class CorporateFormBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The EntityFormBuilder.
+   *
+   * @var \Drupal\Core\Entity\EntityFormBuilder
+   */
+  protected $entityFormBuilder;
+
+  /**
+   * The Renderer.
+   *
+   * @var \Drupal\Core\Render\Renderer
+   */
+  protected $renderer;
+
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new CorporateFormBlock.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFormBuilderInterface $entity_form_builder
+   *   The entity form builder.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer.
+   */
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entityTypeManager, EntityFormBuilderInterface $entity_form_builder, RendererInterface $renderer) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityFormBuilder = $entity_form_builder;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('entity.form_builder'),
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockAccess(AccountInterface $account) {
+    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    $contact_form = $this->getContactForm();
+
+    if (!$contact_form) {
+      return AccessResult::forbidden();
+    }
+
+    return $contact_form->access('access corporate contact form', $account, TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    $contact_form = $this->getContactForm();
+    if (!$contact_form) {
+      return [];
+    }
+    $builder = $this->entityTypeManager->getViewBuilder('contact_form');
+    return $builder->view($contact_form);
+  }
+
+  /**
+   * Returns the derived contact form.
+   *
+   * @return \Drupal\contact\Entity\ContactForm|null
+   *   The contact form entity.
+   */
+  protected function getContactForm(): ?ContactForm {
+    $uuid = $this->getDerivativeId();
+    $contact_form = $this->entityTypeManager->getStorage('contact_form')->loadByProperties(['uuid' => $uuid]);
+    if (!$contact_form) {
+      // Normally, this should not happen but in case the entity has been
+      // deleted.
+      return NULL;
+    }
+
+    return reset($contact_form);
+  }
+
+}

--- a/src/Plugin/Block/CorporateFormBlock.php
+++ b/src/Plugin/Block/CorporateFormBlock.php
@@ -6,13 +6,13 @@ namespace Drupal\oe_contact_forms\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\contact\Entity\ContactForm;
 use Drupal\Core\Entity\EntityFormBuilderInterface;
-use Drupal\Core\Render\RendererInterface;
 
 /**
  * Provides a block that renders a corporate form.
@@ -34,14 +34,6 @@ class CorporateFormBlock extends BlockBase implements ContainerFactoryPluginInte
   protected $entityFormBuilder;
 
   /**
-   * The Renderer.
-   *
-   * @var \Drupal\Core\Render\Renderer
-   */
-  protected $renderer;
-
-
-  /**
    * The entity type manager.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -61,14 +53,11 @@ class CorporateFormBlock extends BlockBase implements ContainerFactoryPluginInte
    *   The entity type manager.
    * @param \Drupal\Core\Entity\EntityFormBuilderInterface $entity_form_builder
    *   The entity form builder.
-   * @param \Drupal\Core\Render\RendererInterface $renderer
-   *   The renderer.
    */
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entityTypeManager, EntityFormBuilderInterface $entity_form_builder, RendererInterface $renderer) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entityTypeManager, EntityFormBuilderInterface $entity_form_builder) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entityTypeManager;
     $this->entityFormBuilder = $entity_form_builder;
-    $this->renderer = $renderer;
   }
 
   /**
@@ -80,36 +69,61 @@ class CorporateFormBlock extends BlockBase implements ContainerFactoryPluginInte
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
-      $container->get('entity.form_builder'),
-      $container->get('renderer')
+      $container->get('entity.form_builder')
     );
+  }
+
+  /**
+   * When the contact form is modified, these cache tags will be invalidated.
+   */
+  public function getCacheTags() {
+    /** @var \Drupal\contact\ContactFormInterface $contact_form */
+    $contact_form = $this->getContactForm();
+    if (!$contact_form) {
+      return [];
+    }
+
+    return Cache::mergeTags(parent::getCacheTags(), $contact_form->getCacheTags());
   }
 
   /**
    * {@inheritdoc}
    */
   public function blockAccess(AccountInterface $account) {
-    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $this->getContactForm();
 
     if (!$contact_form) {
       return AccessResult::forbidden();
     }
 
-    return $contact_form->access('access corporate contact form', $account, TRUE);
+    $access = $this->entityTypeManager->getAccessControlHandler('contact_message')->createAccess($contact_form->id(), $account);
+
+    if (!$access) {
+      return AccessResult::forbidden()->cachePerPermissions();
+    }
+
+    return AccessResult::allowed()->cachePerPermissions()->addCacheTags($contact_form->getCacheTags());
   }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $this->getContactForm();
     if (!$contact_form) {
       return [];
     }
-    $builder = $this->entityTypeManager->getViewBuilder('contact_form');
-    return $builder->view($contact_form);
+
+    /** @var \Drupal\contact\MessageInterface $contact_message */
+    $message = $this->entityTypeManager->getStorage('contact_message')->create([
+      'contact_form' => $contact_form->id(),
+    ]);
+
+    $form = $this->entityFormBuilder->getForm($message, 'corporate_default');
+
+    return $form;
   }
 
   /**
@@ -120,14 +134,14 @@ class CorporateFormBlock extends BlockBase implements ContainerFactoryPluginInte
    */
   protected function getContactForm(): ?ContactForm {
     $uuid = $this->getDerivativeId();
-    $contact_form = $this->entityTypeManager->getStorage('contact_form')->loadByProperties(['uuid' => $uuid]);
-    if (!$contact_form) {
+    $results = $this->entityTypeManager->getStorage('contact_form')->loadByProperties(['uuid' => $uuid]);
+    if (!$results) {
       // Normally, this should not happen but in case the entity has been
       // deleted.
       return NULL;
     }
 
-    return reset($contact_form);
+    return reset($results);
   }
 
 }

--- a/src/Plugin/Derivative/CorporateFormBlock.php
+++ b/src/Plugin/Derivative/CorporateFormBlock.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_contact_forms\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Deriver class for corporate contact form blocks.
+ */
+class CorporateFormBlock extends DeriverBase implements ContainerDeriverInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * LinkListBlock constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    /** @var \Drupal\contact\ContactFormInterface[] $contact_forms */
+    $contact_forms = $this->entityTypeManager->getStorage('contact_form')->loadMultiple();
+    foreach ($contact_forms as $key => $contact_form) {
+      $expose_as_block = $contact_form->getThirdPartySetting('oe_contact_forms', 'expose_as_block', FALSE);
+      $is_corporate_form = $contact_form->getThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
+
+      // Only expose corporate forms configured as block.
+      if ($expose_as_block && $is_corporate_form) {
+        $this->derivatives[$contact_form->uuid()] = $base_plugin_definition;
+        $this->derivatives[$contact_form->uuid()]['admin_label'] = $contact_form->label();
+        $this->derivatives[$contact_form->uuid()]['config_dependencies']['config'] = [$contact_form->getConfigDependencyName()];
+      }
+
+    }
+
+    return $this->derivatives;
+  }
+
+}

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -84,7 +84,7 @@ class MessageFormTest extends WebDriverTestBase {
     $contact_form->setThirdPartySetting('oe_contact_forms', 'email_subject', $settings['email_subject']);
     $settings['header'] = 'this is a test header';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $settings['header']);
-    $settings['privacy_text'] = 'this is a test privacy policy';
+    $settings['privacy_text'] = 'http://example.net';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $settings['privacy_text']);
     $contact_form->setThirdPartySetting('oe_contact_forms', 'includes_fields_in_auto_reply', TRUE);
     $settings['optional_selected'] = ['oe_country_residence' => 'oe_country_residence'];
@@ -147,7 +147,7 @@ class MessageFormTest extends WebDriverTestBase {
     $contact_form->setThirdPartySetting('oe_contact_forms', 'email_subject', $settings['email_subject']);
     $settings['header'] = 'this is a test header';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $settings['header']);
-    $settings['privacy_text'] = 'this is a test privacy policy';
+    $settings['privacy_text'] = 'http://example.net';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $settings['privacy_text']);
     $contact_form->setThirdPartySetting('oe_contact_forms', 'includes_fields_in_auto_reply', TRUE);
     $settings['optional_selected'] = ['oe_country_residence' => 'oe_country_residence'];
@@ -269,7 +269,9 @@ class MessageFormTest extends WebDriverTestBase {
     // Assert header printed.
     $assert->pageTextContains($settings['header']);
     // Assert privacy text.
-    $assert->pageTextContains($settings['privacy_text']);
+    $assert->pageTextContains('Check to accept our privacy policy');
+    // Assert privacy text link.
+    $assert->elementAttributeContains('xpath', "//div[contains(@class, 'form-item-privacy-policy')]//a", 'target', "_blank");
     // Assert topic label.
     $assert->elementTextContains('css', 'label[for="edit-oe-topic"]', $settings['topic_label']);
     // Assert elements order.
@@ -317,7 +319,7 @@ class MessageFormTest extends WebDriverTestBase {
     $page->findButton('Send message')->press();
 
     // Assert confirmation message.
-    $assert->elementTextContains('css', '.messages--status', $settings['privacy_text']);
+    $assert->elementTextNotContains('css', '.messages--status', 'Check to accept our privacy policy');
     $assert->elementTextContains('css', '.messages--status', $settings['topics']['0']['topic_name']);
 
     // Load captured emails to check.

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -4,11 +4,12 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_contact_forms\FunctionalJavascript;
 
-use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\contact\Entity\ContactForm;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Test\AssertMailTrait;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Test Corporate MessageForm behaviour.
@@ -25,6 +26,7 @@ class MessageFormTest extends WebDriverTestBase {
   protected static $modules = [
     'user',
     'system',
+    'block',
     'path',
     'node',
     'contact',
@@ -45,6 +47,19 @@ class MessageFormTest extends WebDriverTestBase {
       'access corporate contact form',
     ]);
     $this->drupalLogin($testuser);
+
+    // Prepare a node as redirect destination.
+    $node_type = NodeType::create(['type' => 'page']);
+    $node_type->save();
+
+    $node = Node::create([
+      'title' => 'Destination',
+      'type' => 'page',
+      'path' => ['alias' => '/destination'],
+      'status' => TRUE,
+      'uid' => 0,
+    ]);
+    $node->save();
   }
 
   /**
@@ -57,62 +72,48 @@ class MessageFormTest extends WebDriverTestBase {
     $page = $this->getSession()->getPage();
 
     // Prepare a corporate contact form.
+    $settings = [];
     $contact_form_id = 'oe_contact_form';
     $contact_form = ContactForm::create(['id' => $contact_form_id]);
     $contact_form->setReply('this is a autoreply');
     $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
     $contact_form->setThirdPartySetting('oe_contact_forms', 'allow_canonical_url', TRUE);
-    $topic_label = 'Topic label';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'topic_label', $topic_label);
-    $email_subject = 'Email Subject';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'email_subject', $email_subject);
-    $header = 'this is a test header';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $header);
-    $privacy_text = 'this is a test privacy policy';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_text);
+    $settings['topic_label'] = 'Topic label';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topic_label', $settings['topic_label']);
+    $settings['email_subject'] = 'Email Subject';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'email_subject', $settings['email_subject']);
+    $settings['header'] = 'this is a test header';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $settings['header']);
+    $settings['privacy_text'] = 'this is a test privacy policy';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $settings['privacy_text']);
     $contact_form->setThirdPartySetting('oe_contact_forms', 'includes_fields_in_auto_reply', TRUE);
-    $optional_selected = ['oe_country_residence' => 'oe_country_residence'];
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'optional_fields', $optional_selected);
-    $topics = [['topic_name' => 'Topic name', 'topic_email_address' => 'topic@emailaddress.com']];
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'topics', $topics);
+    $settings['optional_selected'] = ['oe_country_residence' => 'oe_country_residence'];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'optional_fields', $settings['optional_selected']);
+    $settings['topics'] = [
+      [
+        'topic_name' => 'Topic name',
+        'topic_email_address' => 'topic@emailaddress.com',
+      ],
+    ];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topics', $settings['topics']);
     $contact_form->save();
 
     // Access canonical url.
     $this->drupalGet('contact/' . $contact_form_id);
 
     // Assert corporate fields and optional fields handling.
-    $assert->fieldExists('oe_country_residence[0][target_id]');
-    $assert->fieldNotExists('oe_telephone[0][value]');
-    $assert->fieldExists('oe_topic');
-    $assert->fieldExists('privacy_policy');
-    // Assert header printed.
-    $assert->pageTextContains($header);
-    // Assert privacy text.
-    $assert->pageTextContains($privacy_text);
-    // Assert topic label.
-    $assert->elementTextContains('css', 'label[for="edit-oe-topic"]', $topic_label);
-    // Assert elements order.
-    $elements = $this->xpath('//form');
-    $this->assertCount(1, $elements);
-    // TODO: is there a better method for this ?
-    $html = $elements['0']->getOuterHtml();
-    $i = [];
-    $i['header'] = Unicode::strpos($html, $header);
-    $i['name'] = Unicode::strpos($html, 'edit-name');
-    $i['email'] = Unicode::strpos($html, 'edit-mail');
-    $i['subject'] = Unicode::strpos($html, 'edit-subject-0-value');
-    $i['message'] = Unicode::strpos($html, 'edit-message-0-value');
-    $i['topic'] = Unicode::strpos($html, 'edit-oe-topic');
-    $i['country'] = Unicode::strpos($html, 'edit-oe-country-residence-0-target-id');
-    $i['privacy'] = Unicode::strpos($html, 'edit-privacy-policy');
+    $this->assertMessageForm($settings);
 
-    $this->assertTrue($i['header'] < $i['name']);
-    $this->assertTrue($i['name'] < $i['email']);
-    $this->assertTrue($i['email'] < $i['subject']);
-    $this->assertTrue($i['subject'] < $i['message']);
-    $this->assertTrue($i['message'] < $i['topic']);
-    $this->assertTrue($i['topic'] < $i['country']);
-    $this->assertTrue($i['country'] < $i['privacy']);
+    // Submit the form.
+    $this->assertMessageFormSubmission($settings);
+
+    // Assert that instead of the user being redirected to the homepage,
+    // they are redirected to the same, contact form page.
+    $this->assertUrl('/contact/' . $contact_form_id);
+
+    // Set redirect to an existing path, other then the current one.
+    $contact_form->setRedirectPath('/destination');
+    $contact_form->save();
 
     // Submit the form.
     $page->fillField('subject[0][value]', 'Test subject');
@@ -121,38 +122,74 @@ class MessageFormTest extends WebDriverTestBase {
     $page->findField('privacy_policy')->click();
     $page->findButton('Send message')->press();
 
-    // Assert confirmation message.
-    $assert->elementTextContains('css', '.messages--status', $privacy_text);
-    $assert->elementTextContains('css', '.messages--status', $topics['0']['topic_name']);
+    // Assert that the user is being redirected to the path set.
+    $this->assertUrl('/destination');
+  }
 
-    // Load captured emails to check.
-    $captured_emails = $this->drupalGetMails();
-    $this->assertTrue(count($captured_emails) === 2);
+  /**
+   * Tests for corporate forms block behaviour.
+   */
+  public function testCorporateBlockForm(): void {
+    /** @var \Behat\Mink\Element\DocumentElement $page */
+    $page = $this->getSession()->getPage();
 
-    // Assert email subject.
-    $this->assertTrue($captured_emails[0]['subject'] === $email_subject);
-    // Assert email recipients.
-    $this->assertTrue($captured_emails[0]['to'] === $topics['0']['topic_email_address']);
-    // Make sure we have an autoreply.
-    $this->assertTrue($captured_emails[1]['id'] === 'contact_page_autoreply');
-    // Assert fields in autoreply.
-    $this->assertTrue(strpos($captured_emails[1]['body'], 'Test subject') !== FALSE);
-    $this->assertTrue(strpos($captured_emails[1]['body'], 'Test message') !== FALSE);
-    $this->assertTrue(strpos($captured_emails[1]['body'], $topics['0']['topic_name']) !== FALSE);
+    // Prepare a corporate contact form.
+    $settings = [];
+    $contact_form_id = 'oe_contact_form';
+    $contact_form = ContactForm::create(['id' => $contact_form_id]);
+    $contact_form->setReply('this is a autoreply');
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'allow_canonical_url', FALSE);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', TRUE);
+    $settings['topic_label'] = 'Topic label';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topic_label', $settings['topic_label']);
+    $settings['email_subject'] = 'Email Subject';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'email_subject', $settings['email_subject']);
+    $settings['header'] = 'this is a test header';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $settings['header']);
+    $settings['privacy_text'] = 'this is a test privacy policy';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $settings['privacy_text']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'includes_fields_in_auto_reply', TRUE);
+    $settings['optional_selected'] = ['oe_country_residence' => 'oe_country_residence'];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'optional_fields', $settings['optional_selected']);
+    $settings['topics'] = [
+      [
+        'topic_name' => 'Topic name',
+        'topic_email_address' => 'topic@emailaddress.com',
+      ],
+    ];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topics', $settings['topics']);
+    $contact_form->save();
 
-    // Assert that instead of the user being redirected to the homepage,
-    // they are redirected to the same, contact form page.
-    $this->assertUrl('/contact/' . $contact_form_id);
-
-    // Set redirect to an existing path, other then the current one.
+    // Place the block on a page.
     $node = Node::create([
-      'title' => 'Destination',
+      'title' => 'Block Page',
       'type' => 'page',
-      'path' => ['alias' => '/destination'],
+      'path' => ['alias' => '/block-page'],
       'status' => TRUE,
       'uid' => 0,
     ]);
     $node->save();
+    $block = $this->placeBlock('oe_contact_forms_corporate_block:' . $contact_form->uuid(), [
+      'visibility' => [
+        'request_path' => [
+          'pages' => '/block-page',
+        ],
+      ],
+    ]);
+    $this->drupalGet('/block-page');
+
+    // Assert corporate fields and optional fields handling.
+    $this->assertMessageForm($settings);
+
+    // Submit the form.
+    $this->assertMessageFormSubmission($settings);
+
+    // Assert that instead of the user being redirected to the homepage,
+    // they are redirected to the same page.
+    $this->assertUrl('/block-page');
+
+    // Set redirect to an existing path, other then the current one.
     $contact_form->setRedirectPath('/destination');
     $contact_form->save();
 
@@ -208,6 +245,95 @@ class MessageFormTest extends WebDriverTestBase {
     // Assert that non-corporate forms are being redirected to the homepage
     // (which in the case of the test setup is the user page).
     $this->assertUrl('/user/' . $this->loggedInUser->id());
+  }
+
+  /**
+   * Assert the fields are as defined in corporate form settings.
+   *
+   * @param array $settings
+   *   The corporate form settings.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @throws \Behat\Mink\Exception\ElementTextException
+   * @throws \Behat\Mink\Exception\ExpectationException
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   */
+  protected function assertMessageForm(array &$settings = []) {
+    /** @var \Behat\Mink\WebAssert $assert */
+    $assert = $this->assertSession();
+    // Assert corporate fields.
+    $assert->fieldExists('oe_country_residence[0][target_id]');
+    $assert->fieldNotExists('oe_telephone[0][value]');
+    $assert->fieldExists('oe_topic');
+    $assert->fieldExists('privacy_policy');
+    // Assert header printed.
+    $assert->pageTextContains($settings['header']);
+    // Assert privacy text.
+    $assert->pageTextContains($settings['privacy_text']);
+    // Assert topic label.
+    $assert->elementTextContains('css', 'label[for="edit-oe-topic"]', $settings['topic_label']);
+    // Assert elements order.
+    $elements = $this->xpath('//form');
+    $this->assertCount(1, $elements);
+    // TODO: is there a better method for this ?
+    $html = $elements['0']->getOuterHtml();
+    $i = [];
+    $i['header'] = Unicode::strpos($html, $settings['header']);
+    $i['name'] = Unicode::strpos($html, 'edit-name');
+    $i['email'] = Unicode::strpos($html, 'edit-mail');
+    $i['subject'] = Unicode::strpos($html, 'edit-subject-0-value');
+    $i['message'] = Unicode::strpos($html, 'edit-message-0-value');
+    $i['topic'] = Unicode::strpos($html, 'edit-oe-topic');
+    $i['country'] = Unicode::strpos($html, 'edit-oe-country-residence-0-target-id');
+    $i['privacy'] = Unicode::strpos($html, 'edit-privacy-policy');
+
+    $this->assertTrue($i['header'] < $i['name']);
+    $this->assertTrue($i['name'] < $i['email']);
+    $this->assertTrue($i['email'] < $i['subject']);
+    $this->assertTrue($i['subject'] < $i['message']);
+    $this->assertTrue($i['message'] < $i['topic']);
+    $this->assertTrue($i['topic'] < $i['country']);
+    $this->assertTrue($i['country'] < $i['privacy']);
+  }
+
+  /**
+   * Assert corporate form behaviour.
+   *
+   * @param array $settings
+   *   The corporate form settings.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @throws \Behat\Mink\Exception\ElementTextException
+   */
+  protected function assertMessageFormSubmission(array &$settings = []) {
+    /** @var \Behat\Mink\WebAssert $assert */
+    $assert = $this->assertSession();
+    /** @var \Behat\Mink\Element\DocumentElement $page */
+    $page = $this->getSession()->getPage();
+    $page->fillField('subject[0][value]', 'Test subject');
+    $page->fillField('message[0][value]', 'Test message');
+    $page->selectFieldOption('oe_topic', 'Topic name');
+    $page->findField('privacy_policy')->click();
+    $page->findButton('Send message')->press();
+
+    // Assert confirmation message.
+    $assert->elementTextContains('css', '.messages--status', $settings['privacy_text']);
+    $assert->elementTextContains('css', '.messages--status', $settings['topics']['0']['topic_name']);
+
+    // Load captured emails to check.
+    $captured_emails = $this->drupalGetMails();
+    $this->assertTrue(count($captured_emails) === 2);
+
+    // Assert email subject.
+    $this->assertTrue($captured_emails[0]['subject'] === $settings['email_subject']);
+    // Assert email recipients.
+    $this->assertTrue($captured_emails[0]['to'] === $settings['topics']['0']['topic_email_address']);
+    // Make sure we have an autoreply.
+    $this->assertTrue($captured_emails[1]['id'] === 'contact_page_autoreply');
+    // Assert fields in autoreply.
+    $this->assertTrue(strpos($captured_emails[1]['body'], 'Test subject') !== FALSE);
+    $this->assertTrue(strpos($captured_emails[1]['body'], 'Test message') !== FALSE);
+    $this->assertTrue(strpos($captured_emails[1]['body'], $settings['topics']['0']['topic_name']) !== FALSE);
   }
 
 }

--- a/tests/src/FunctionalJavascript/SettingsFormTest.php
+++ b/tests/src/FunctionalJavascript/SettingsFormTest.php
@@ -20,7 +20,7 @@ class SettingsFormTest extends WebDriverTestBase {
     'corporate_fields[topic_label]' => 'Topic label',
     'corporate_fields[email_subject]' => 'Email subject',
     'corporate_fields[header]' => 'Header text',
-    'corporate_fields[privacy_policy]' => 'Privacy text',
+    'corporate_fields[privacy_policy]' => 'http://example.net',
     'corporate_fields[includes_fields_in_auto_reply]' => TRUE,
     'corporate_fields[allow_canonical_url]' => TRUE,
     // For expose_as_block default is true so we test false.
@@ -408,7 +408,7 @@ class SettingsFormTest extends WebDriverTestBase {
       'topic_label' => 'Topic label',
       'email_subject' => 'Email subject',
       'header' => 'Header text',
-      'privacy_policy' => 'Privacy text',
+      'privacy_policy' => 'http://example.net',
       'includes_fields_in_auto_reply' => TRUE,
       'allow_canonical_url' => TRUE,
       'expose_as_block' => FALSE,

--- a/tests/src/FunctionalJavascript/SettingsFormTest.php
+++ b/tests/src/FunctionalJavascript/SettingsFormTest.php
@@ -9,7 +9,7 @@ use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 /**
  * Tests the corporate contact forms.
  */
-class CorporateContactFormTest extends WebDriverTestBase {
+class SettingsFormTest extends WebDriverTestBase {
 
   /**
    * Corporate fields to test against.

--- a/tests/src/Kernel/BlocksTest.php
+++ b/tests/src/Kernel/BlocksTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_contact_forms\Kernel;
+
+use Drupal\contact\Entity\ContactForm;
+
+/**
+ * Tests contact form block derivatives.
+ */
+class BlocksTest extends ContactFormTestBase {
+
+  /**
+   * Tests that we have a block derivative for exposed contact forms.
+   */
+  public function testBlockDerivatives(): void {
+    /** @var \Drupal\Core\Block\BlockManagerInterface $block_manager */
+    $block_manager = $this->container->get('plugin.manager.block');
+
+    $contact_form = ContactForm::create(['id' => 'oe_contact_form']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', TRUE);
+    $contact_form->save();
+
+    // Assert the block was created.
+    $this->assertTrue($block_manager->hasDefinition('oe_contact_forms_corporate_block:' . $contact_form->uuid()));
+
+    $contact_form = ContactForm::create(['id' => 'oe_contact_form_no_block']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'expose_as_block', TRUE);
+    $contact_form->save();
+
+    // Assert the block was not created.
+    $this->assertFalse($block_manager->hasDefinition('oe_contact_forms_corporate_block:' . $contact_form->uuid()));
+
+    $contact_form = ContactForm::create(['id' => 'default_contact_form']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
+    $contact_form->save();
+
+    // Assert the block was not created.
+    $this->assertFalse($block_manager->hasDefinition('oe_contact_forms_corporate_block:' . $contact_form->uuid()));
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-3293

### Description

Change oe_contact_forms_form_contact_form_form_alter to have privacy_policy field:

type #url instead of textarea.
'#title' - Privacy policy link
'description' - Link to form privacy policy/data protection page

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

