### PR TITLE
OPENEUROPA-3293: Change privacy field to url and update test.

### DIFF
--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -159,10 +159,10 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
       '#default_value' => $contact_form->getThirdPartySetting('oe_contact_forms', 'header', ''),
     ];
     $form['corporate_fields']['privacy_policy'] = [
-      '#type' => 'textarea',
-      '#title' => t('Privacy policy'),
+      '#type' => 'url',
+      '#title' => t('Privacy policy link'),
       '#required' => TRUE,
-      '#description' => t("Please specify a privacy policy message to display on the form."),
+      '#description' => t("Link to form privacy policy/data protection page."),
       '#default_value' => $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', ''),
     ];
     $form['corporate_fields']['includes_fields_in_auto_reply'] = [

--- a/src/Form/ContactMessageForm.php
+++ b/src/Form/ContactMessageForm.php
@@ -24,8 +24,8 @@ class ContactMessageForm extends MessageForm {
     $message = $this->entity;
     /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $message->getContactForm();
-
     $header = $contact_form->getThirdPartySetting('oe_contact_forms', 'header', FALSE);
+    $privacy_link = $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', FALSE);
 
     if (!empty($header)) {
       $form['header'] = [
@@ -36,8 +36,7 @@ class ContactMessageForm extends MessageForm {
     // Checkbox to accept privacy policy configured in the ContactForm.
     $form['privacy_policy'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('I accept privacy policy'),
-      '#description' => $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy'),
+      '#title' => $this->t('I have read and agree with the <a href="@link" target="_blank">data protection terms</a>', ['@link' => $privacy_link]),
       '#required' => TRUE,
     ];
 
@@ -103,12 +102,6 @@ class ContactMessageForm extends MessageForm {
     parent::save($form, $form_state);
 
     // Apart from the confirmation message also include the following.
-    // Privacy notice.
-    $privacy_policy = $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', '');
-
-    if (!empty($privacy_policy)) {
-      $this->messenger()->addMessage($privacy_policy);
-    }
     // The values of the submitted fields.
     $full_view = $this->entityTypeManager->getViewBuilder('contact_message')->view($message, 'full');
     $this->messenger()->addMessage($full_view);

--- a/tests/src/FunctionalJavascript/CorporateContactFormTest.php
+++ b/tests/src/FunctionalJavascript/CorporateContactFormTest.php
@@ -20,7 +20,7 @@ class CorporateContactFormTest extends WebDriverTestBase {
     'corporate_fields[topic_label]' => 'Topic label',
     'corporate_fields[email_subject]' => 'Email subject',
     'corporate_fields[header]' => 'Header text',
-    'corporate_fields[privacy_policy]' => 'Privacy text',
+    'corporate_fields[privacy_policy]' => 'http://example.net',
     'corporate_fields[includes_fields_in_auto_reply]' => TRUE,
     'corporate_fields[allow_canonical_url]' => TRUE,
     // For expose_as_block default is true so we test false.
@@ -408,7 +408,7 @@ class CorporateContactFormTest extends WebDriverTestBase {
       'topic_label' => 'Topic label',
       'email_subject' => 'Email subject',
       'header' => 'Header text',
-      'privacy_policy' => 'Privacy text',
+      'privacy_policy' => 'http://example.net',
       'includes_fields_in_auto_reply' => TRUE,
       'allow_canonical_url' => TRUE,
       'expose_as_block' => FALSE,

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -68,8 +68,8 @@ class MessageFormTest extends WebDriverTestBase {
     $contact_form->setThirdPartySetting('oe_contact_forms', 'email_subject', $email_subject);
     $header = 'this is a test header';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $header);
-    $privacy_text = 'this is a test privacy policy';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_text);
+    $privacy_url = 'http://example.net';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_url);
     $contact_form->setThirdPartySetting('oe_contact_forms', 'includes_fields_in_auto_reply', TRUE);
     $optional_selected = ['oe_country_residence' => 'oe_country_residence'];
     $contact_form->setThirdPartySetting('oe_contact_forms', 'optional_fields', $optional_selected);
@@ -88,7 +88,9 @@ class MessageFormTest extends WebDriverTestBase {
     // Assert header printed.
     $assert->pageTextContains($header);
     // Assert privacy text.
-    $assert->pageTextContains($privacy_text);
+    $assert->pageTextContains('I have read and agree with the data protection terms');
+    // Assert privacy text link.
+    $assert->elementAttributeContains('xpath', "//div[contains(@class, 'form-item-privacy-policy')]//a", 'target', "_blank");
     // Assert topic label.
     $assert->elementTextContains('css', 'label[for="edit-oe-topic"]', $topic_label);
     // Assert elements order.
@@ -122,7 +124,6 @@ class MessageFormTest extends WebDriverTestBase {
     $page->findButton('Send message')->press();
 
     // Assert confirmation message.
-    $assert->elementTextContains('css', '.messages--status', $privacy_text);
     $assert->elementTextContains('css', '.messages--status', $topics['0']['topic_name']);
 
     // Load captured emails to check.

--- a/tests/src/Kernel/BlocksTest.php
+++ b/tests/src/Kernel/BlocksTest.php
@@ -25,8 +25,9 @@ class BlocksTest extends ContactFormTestBase {
     $contact_form->setThirdPartySetting('oe_contact_forms', 'topic_label', $topic_label);
     $header = 'this is a test header';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $header);
-    $privacy_text = 'this is a test privacy policy';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_text);
+    $privacy_url = 'http://example.net';
+    $privacy_text = "I have read and agree with the <a href=\"{$privacy_url}\" target=\"_blank\">data protection terms</a>";
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_url);
     $topics = [['topic_name' => 'Topic name', 'topic_email_address' => 'topic@emailaddress.com']];
     $contact_form->setThirdPartySetting('oe_contact_forms', 'topics', $topics);
     $contact_form->save();
@@ -41,7 +42,7 @@ class BlocksTest extends ContactFormTestBase {
 
     // Assert we have correct build.
     $this->assertEqual($build['header']['#markup'], $header);
-    $this->assertEqual($build['privacy_policy']['#description'], $privacy_text);
+    $this->assertEqual($build['privacy_policy']['#title'], $privacy_text);
     $this->assertEqual($build['oe_topic']['widget']['#title'], $topic_label);
 
     // Remove from derivatives.


### PR DESCRIPTION
## OPENEUROPA-3293

### Description

Changed privacy policy to url, changed the field display.

### Change log

- Changed:
   - privacy field settings and render definition
   - adapt tests to changes above

