### PR TITLE
EWPP-20: Use the RDF skos entity reference select widget

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     # ports:
     #   - 3306:3306
   sparql:
-    image: openeuropa/triple-store-dev:1.2.0
+    image: openeuropa/triple-store-dev:1.3.0
     environment:
     - SPARQL_UPDATE=true
     - DBA_PASSWORD=dba

--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -432,7 +432,7 @@ function oe_contact_forms_entity_base_field_info(EntityTypeInterface $entity_typ
         ],
       ])
       ->setDisplayOptions('form', [
-        'type' => 'skos_concept_entity_reference_autocomplete',
+        'type' => 'skos_concept_entity_reference_options_select',
       ])
       ->setDisplayOptions('view', [
         'weight' => 0,

--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -534,6 +534,7 @@ function oe_contact_forms_entity_form_display_alter(EntityFormDisplayInterface $
       ])
       ->setComponent('oe_country_residence', [
         'weight' => 5,
+        'type' => 'skos_concept_entity_reference_options_select',
       ])
       ->setComponent('oe_telephone', [
         'weight' => 6,

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -9,6 +9,7 @@ use Drupal\contact\Entity\ContactForm;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Test\AssertMailTrait;
 use Drupal\node\Entity\Node;
+use Drupal\Tests\rdf_entity\Traits\RdfDatabaseConnectionTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 
@@ -16,6 +17,8 @@ use Drupal\user\RoleInterface;
  * Test Corporate MessageForm behaviour.
  */
 class MessageFormTest extends WebDriverTestBase {
+
+  use RdfDatabaseConnectionTrait;
 
   use AssertMailTrait {
     getMails as drupalGetMails;
@@ -83,7 +86,7 @@ class MessageFormTest extends WebDriverTestBase {
     $this->drupalGet('contact/' . $contact_form_id);
 
     // Assert corporate fields and optional fields handling.
-    $assert->fieldExists('oe_country_residence[0][target_id]');
+    $assert->fieldExists('oe_country_residence');
     $assert->fieldNotExists('oe_telephone[0][value]');
     $assert->fieldExists('oe_topic');
     $assert->fieldExists('privacy_policy');
@@ -106,7 +109,7 @@ class MessageFormTest extends WebDriverTestBase {
     $i['subject'] = Unicode::strpos($html, 'edit-subject-0-value');
     $i['message'] = Unicode::strpos($html, 'edit-message-0-value');
     $i['topic'] = Unicode::strpos($html, 'edit-oe-topic');
-    $i['country'] = Unicode::strpos($html, 'edit-oe-country-residence-0-target-id');
+    $i['country'] = Unicode::strpos($html, 'edit-oe-country-residence');
     $i['privacy'] = Unicode::strpos($html, 'edit-privacy-policy');
 
     $this->assertTrue($i['name'] < $i['email']);

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -145,7 +145,7 @@ class MessageFormTest extends WebDriverTestBase {
     $assert->pageTextContains($topic_label);
     $assert->pageTextContains($header);
     $assert->elementAttributeContains('xpath', "//div[contains(@class, 'form-item-privacy-policy')]//a", 'href', $privacy_url);
-    $assert->fieldExists('oe_country_residence[0][target_id]');
+    $assert->fieldExists('oe_country_residence');
     $assert->fieldExists('oe_telephone[0][value]');
 
     foreach ($topics as $topic) {


### PR DESCRIPTION
## EWPP-20

### Description

When selecting the countries, use the select widget instead of the autocomplete and update test for country select widget on contact forms.

### Change log

- Changed:
  - Country widget selector to skos_concept_entity_reference_options_select
  - MessageFormTest.php for country selector


