### PR TITLE
EWPP-772: Remove HTML markup in the contact form emails.

### DIFF
--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -56,7 +56,7 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
     ],
   ];
 
-  // Adding checkbox with ajax callback that managed addionals fields.
+  // Adding checkbox with ajax callback that manages additional fields.
   $form['is_corporate_form'] = [
     '#type' => 'checkbox',
     '#title' => t('Is corporate form'),
@@ -673,6 +673,12 @@ function oe_contact_forms_mail_alter(&$message) {
 
   // Change subject for corporate mail, copy and reply.
   $message['subject'] = $contact_form->getThirdPartySetting('oe_contact_forms', 'email_subject');
+
+  // Set back the auto-reply in case contact_storage re-rendered it.
+  // @see contact_storage_mail_alter.
+  if ($message['key'] === 'page_autoreply') {
+    $message['body'] = [$contact_form->getReply()];
+  }
 }
 
 /**

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -186,10 +186,6 @@ class MessageFormTest extends WebDriverTestBase {
     $this->assertTrue($captured_emails[0]['to'] === $topics['0']['topic_email_address']);
     // Make sure we have an autoreply.
     $this->assertTrue($captured_emails[1]['id'] === 'contact_page_autoreply');
-    // Assert fields in autoreply.
-    $this->assertTrue(strpos($captured_emails[1]['body'], 'Test subject') !== FALSE);
-    $this->assertTrue(strpos($captured_emails[1]['body'], 'Test message') !== FALSE);
-    $this->assertTrue(strpos($captured_emails[1]['body'], $topics['0']['topic_name']) !== FALSE);
     $this->assertTestEmailBodies($captured_emails);
 
     // Assert that instead of the user being redirected to the homepage,
@@ -291,17 +287,18 @@ class MessageFormTest extends WebDriverTestBase {
    */
   protected function assertTestEmailBodies(array $captured_emails): void {
     // First email is the outgoing one.
-    $expected = 'tester (not verified) (tester@example.com) sent a message using the contact
+    $expected = <<<EOF
+tester (not verified) (tester@example.com) sent a message using the contact
 form at http://web:8080/build/contact/oe_contact_form.
 
 
 
-      The sender\'s name
+      The sender's name
                 tester
 
 
 
-      The sender\'s email
+      The sender's email
                 tester@example.com
 
 
@@ -318,20 +315,22 @@ form at http://web:8080/build/contact/oe_contact_form.
 
       Topic
                 Changed name
-';
 
-    $this->assertEquals($expected, $captured_emails[0]['body']);
+EOF;
+
+    $this->assertEquals(preg_replace('/\s+/', ' ', $expected), preg_replace('/\s+/', ' ', $captured_emails[0]['body']));
 
     // The second is the autoreply.
-    $expected = 'this is a autoreply
+    $expected = <<<EOF
+this is a autoreply
 
 
-      The sender\'s name
+      The sender's name
                 tester
 
 
 
-      The sender\'s email
+      The sender's email
                 tester@example.com
 
 
@@ -348,9 +347,10 @@ form at http://web:8080/build/contact/oe_contact_form.
 
       Topic
                 Changed name
-';
 
-    $this->assertEquals($expected, $captured_emails[1]['body']);
+EOF;
+
+    $this->assertEquals(preg_replace('/\s+/', ' ', $expected), preg_replace('/\s+/', ' ', $captured_emails[1]['body']));
   }
 
 }

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -190,6 +190,7 @@ class MessageFormTest extends WebDriverTestBase {
     $this->assertTrue(strpos($captured_emails[1]['body'], 'Test subject') !== FALSE);
     $this->assertTrue(strpos($captured_emails[1]['body'], 'Test message') !== FALSE);
     $this->assertTrue(strpos($captured_emails[1]['body'], $topics['0']['topic_name']) !== FALSE);
+    $this->assertTestEmailBodies($captured_emails);
 
     // Assert that instead of the user being redirected to the homepage,
     // they are redirected to the same, contact form page.
@@ -278,6 +279,78 @@ class MessageFormTest extends WebDriverTestBase {
 
     // Assert that non-corporate forms are being redirected to the homepage.
     $this->assertUrl('/');
+  }
+
+  /**
+   * Asserts the sent emails are correctly formatted.
+   *
+   * @param array $captured_emails
+   *   The captured emails that were sent out: main one and auto-reply.
+   *
+   * @see self::testCorporateForm
+   */
+  protected function assertTestEmailBodies(array $captured_emails): void {
+    // First email is the outgoing one.
+    $expected = 'tester (not verified) (tester@example.com) sent a message using the contact
+form at http://web:8080/build/contact/oe_contact_form.
+
+
+
+      The sender\'s name
+                tester
+
+
+
+      The sender\'s email
+                tester@example.com
+
+
+
+      Subject
+                Test subject
+
+
+
+      Message
+                Test message
+
+
+
+      Topic
+                Changed name
+';
+
+    $this->assertEquals($expected, $captured_emails[0]['body']);
+
+    // The second is the autoreply.
+    $expected = 'this is a autoreply
+
+
+      The sender\'s name
+                tester
+
+
+
+      The sender\'s email
+                tester@example.com
+
+
+
+      Subject
+                Test subject
+
+
+
+      Message
+                Test message
+
+
+
+      Topic
+                Changed name
+';
+
+    $this->assertEquals($expected, $captured_emails[1]['body']);
   }
 
 }


### PR DESCRIPTION
## EWPP-772

### Description

Removes the HTML markup in the contact form emails

### Change log

- Added: Instructions for installing MailDev
- Fixed: HTML markup removed