### PR TITLE
OEL-164: Drupal 9 compatibility fixes for oe_contact_forms.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,13 +25,14 @@ services:
 
   selenium:
     image: registry.fpfis.eu/fpfis/selenium:standalone-chrome-3.141.59-oxygen
-    pull: true
     shm_size: 2g
     environment:
       - DISPLAY=:99
       - SE_OPTS=-debug
       - SCREEN_WIDTH=1280
       - SCREEN_HEIGHT=800
+      - NODE_MAX_INSTANCES=5
+      - NODE_MAX_SESSION=5
 
   sparql:
     image: registry.fpfis.eu/openeuropa/triple-store-dev
@@ -97,5 +98,4 @@ matrix:
     - lowest
     - highest
   PHP_VERSION:
-    - 7.2
     - 7.3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The OpenEuropa Contact Forms project provides storage for Contact messages in th
 
 ## Usage
 
-Corporate contact form behaviour can be enabled on the contact form add/edit page, allowing form fields, confirmation message and email values to be defined. 
+Corporate contact form behaviour can be enabled on the contact form add/edit page, allowing form fields, confirmation message and email values to be defined.
 
 ## Permissions
 
@@ -37,30 +37,40 @@ composer install
 ```
 
 A post command hook (`drupal:site-setup`) is triggered automatically after `composer install`.
-It will make sure that the necessary symlinks are properly setup in the development site.
-It will also perform token substitution in development configuration files such as `behat.yml.dist`.
+This will symlink the module in the proper directory within the test site and perform token substitution in test configuration files such as `behat.yml.dist`.
+
+**Please note:** project files and directories are symlinked within the test site by using the
+[OpenEuropa Task Runner's Drupal project symlink](https://github.com/openeuropa/task-runner-drupal-project-symlink) command.
+
+If you add a new file or directory in the root of the project, you need to re-run `drupal:site-setup` in order to make
+sure they are be correctly symlinked.
+
+If you don't want to re-run a full site setup for that, you can simply run:
+
+```
+$ ./vendor/bin/run drupal:symlink-project
 
 * Install test site by running:
 
 ```bash
-./vendor/bin/run drupal:site-install
+$ ./vendor/bin/run drupal:site-install
 ```
 
 The development site web root should be available in the `build` directory.
 
 ### Using Docker Compose
 
-Alternatively, you can build a development site using [Docker](https://www.docker.com/get-docker) and 
+Alternatively, you can build a development site using [Docker](https://www.docker.com/get-docker) and
 [Docker Compose](https://docs.docker.com/compose/) with the provided configuration.
 
-Docker provides the necessary services and tools such as a web server and a database server to get the site running, 
+Docker provides the necessary services and tools such as a web server and a database server to get the site running,
 regardless of your local host configuration.
 
 #### Configuration
 
 By default, Docker Compose reads two files, a `docker-compose.yml` and an optional `docker-compose.override.yml` file.
 By convention, the `docker-compose.yml` contains your base configuration and it's provided by default.
-The override file, as its name implies, can contain configuration overrides for existing services or entirely new 
+The override file, as its name implies, can contain configuration overrides for existing services or entirely new
 services.
 If a service is defined in both files, Docker Compose merges the configurations.
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,7 +2,7 @@ default:
   suites:
     default:
       paths:
-        - %paths.base%/tests/features
+        - "%paths.base%/tests/features"
       contexts:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\DrupalContext

--- a/composer.json
+++ b/composer.json
@@ -6,26 +6,26 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.8",
+        "drupal/core": "^8.9 || ^9.1",
         "drupal/contact_storage": "1.0.0",
         "drupal/contact_storage_export": "^1.13",
         "easyrdf/easyrdf": "1.0.0 as 0.9.1",
         "openeuropa/rdf_skos": "~1.0",
         "openeuropa/oe_corporate_countries": "~2.0",
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "require-dev": {
-        "composer/installers": "~1.5",
-        "drupal/core-composer-scaffold": "^8.8",
-        "drupal/coder": "8.3.8",
+        "composer/installers": "^1.11",
         "drupal/config_devel": "~1.2",
+        "drupal/core-composer-scaffold": "^8.9 || ^9.1",
         "drupal/drupal-extension": "~4.0",
-        "drush/drush": "~9.7@stable",
+        "drush/drush": "^10.3",
         "guzzlehttp/guzzle": "~6.3",
-        "openeuropa/code-review": "~1.0.0-beta2",
-        "openeuropa/drupal-core-require-dev": "^8.9.13",
+        "openeuropa/code-review": "^1.6",
+        "openeuropa/drupal-core-require-dev": "^8.9 || ^9.1",
         "openeuropa/task-runner": "~1.0.0-beta5",
-        "phpunit/phpunit": "~6.0"
+        "openeuropa/task-runner-drupal-project-symlink": "^1.0",
+        "phpspec/prophecy-phpunit": "^1 || ^2"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
   # @link https://github.com/elgalu/docker-selenium/issues/20
   selenium:
     image: selenium/standalone-chrome-debug:3.141.59-oxygen
+    expose:
+      - '4444'
     environment:
       - DISPLAY=:99
       - SE_OPTS=-debug
@@ -45,6 +47,8 @@ services:
     ports:
       - '4444:4444'
       - '5900:5900'
+    volumes:
+      - /dev/shm:/dev/shm
     shm_size: 2g
 
 #### Mac users: uncomment the "volumes" key to enable the NFS file sharing. You can find more information about Docker for Mac here: https://github.com/openeuropa/openeuropa/blob/master/docs/starting/tooling.md#using-docker-on-macos

--- a/oe_contact_forms.info.yml
+++ b/oe_contact_forms.info.yml
@@ -3,7 +3,7 @@ description: The OpenEuropa Contact Forms provides contact form configurations.
 package: OpenEuropa
 
 type: module
-core: 8.x
+core_version_requirement: ^8 || ^9
 
 dependencies:
   - drupal:telephone

--- a/oe_contact_forms.install
+++ b/oe_contact_forms.install
@@ -12,10 +12,10 @@ declare(strict_types = 1);
  */
 function oe_contact_forms_install() {
   // Configure the RDF SKOS graphs.
-  if (!\Drupal::service('config.installer')->isSyncing()) {
+  if (!Drupal::service('config.installer')->isSyncing()) {
     $graphs = [
       'country' => 'http://publications.europa.eu/resource/authority/country',
     ];
-    \Drupal::service('rdf_skos.skos_graph_configurator')->addGraphs($graphs);
+    Drupal::service('rdf_skos.skos_graph_configurator')->addGraphs($graphs);
   }
 }

--- a/oe_contact_forms.module
+++ b/oe_contact_forms.module
@@ -182,12 +182,12 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
       '#title' => t('Privacy policy link'),
       '#required' => TRUE,
       '#description' => t("Link to form privacy policy/data protection page."),
-      '#element_validate' => array(
-        array(
+      '#element_validate' => [
+        [
           '\Drupal\link\Plugin\Field\FieldWidget\LinkWidget',
           'validateUriElement',
-        ),
-      ),
+        ],
+      ],
       '#maxlength' => 2048,
       '#process_default_value' => FALSE,
       '#default_value' => _oe_contact_forms_get_privacy_default($contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', '')),
@@ -243,6 +243,7 @@ function oe_contact_forms_form_contact_form_form_alter(&$form, FormStateInterfac
  *   The URI to get the displayable string for.
  *
  * @return string
+ *   The URI without the 'internal:' or 'entity:' scheme
  *
  * @see \Drupal\link\Plugin\Field\FieldWidget\LinkWidget::getUriAsDisplayableString()
  */
@@ -268,9 +269,9 @@ function _oe_contact_forms_get_privacy_default(string $uri): string {
   elseif ($scheme === 'entity') {
     [$entity_type, $entity_id] = explode('/', substr($uri, 7), 2);
     // Show the 'entity:' URI as the entity autocomplete would.
-    // @todo Support entity types other than 'node'. Will be fixed in
-    //    https://www.drupal.org/node/2423093.
-    if ($entity_type == 'node' && $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id)) {
+    // @todo   Support entity types other than 'node'. Will be fixed in
+    //   https://www.drupal.org/node/2423093.
+    if ($entity_type == 'node' && $entity = Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id)) {
       $displayable_string = EntityAutocomplete::getEntityLabels([$entity]);
     }
   }
@@ -285,7 +286,7 @@ function _oe_contact_forms_get_privacy_default(string $uri): string {
  * Clear block cached definitions.
  */
 function _oe_contact_forms_clear_block_cached_definitions(): void {
-  \Drupal::service('plugin.manager.block')->clearCachedDefinitions();
+  Drupal::service('plugin.manager.block')->clearCachedDefinitions();
 }
 
 /**
@@ -294,7 +295,7 @@ function _oe_contact_forms_clear_block_cached_definitions(): void {
 function oe_contact_forms_contact_form_presave(EntityInterface $entity) {
   _oe_contact_forms_clear_block_cached_definitions();
   // Invalidate form display cache tags if config is changed,
-  // since the EntityFormDisplay is not in storage we compose the tag.;
+  // since the EntityFormDisplay is not in storage we compose the tag.
   Cache::invalidateTags(['config:core.entity_form_display.contact_message.' . $entity->id() . '.corporate_default']);
 }
 
@@ -443,7 +444,7 @@ function _oe_contact_forms_contact_form_builder($entity_type, ContactFormInterfa
 function _oe_contact_forms_email_validate(array &$form, FormStateInterface $form_state): void {
   $values = $form_state->getValue('corporate_fields');
   $topics_fieldset = &$values['topics_fieldset'];
-  $email_validator = \Drupal::service('email.validator');
+  $email_validator = Drupal::service('email.validator');
 
   foreach ($topics_fieldset['group'] as $delta => &$topic) {
     if (empty($topic['topic_email_address'])) {
@@ -659,7 +660,11 @@ function oe_contact_forms_entity_form_display_alter(EntityFormDisplayInterface $
 function oe_contact_forms_mail_alter(&$message) {
   // Check if its a corporate contact form.
   $is_corporate_form = FALSE;
-  $mail_ids = ['contact_page_mail', 'contact_page_copy', 'contact_page_autoreply'];
+  $mail_ids = [
+    'contact_page_mail',
+    'contact_page_copy',
+    'contact_page_autoreply',
+  ];
 
   if (isset($message['params']['contact_form'])) {
     /** @var \Drupal\contact\ContactFormInterface $contact_form */

--- a/oe_contact_forms.post_update.php
+++ b/oe_contact_forms.post_update.php
@@ -11,6 +11,6 @@ declare(strict_types = 1);
  * Enable the corporate countries component.
  */
 function oe_contact_forms_post_update_00001(): void {
-  \Drupal::service('module_installer')->install(['oe_corporate_countries']);
-  \Drupal::service('kernel')->invalidateContainer();
+  Drupal::service('module_installer')->install(['oe_corporate_countries']);
+  Drupal::service('kernel')->invalidateContainer();
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true" >
+<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true" cacheResult="false">
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -48,7 +48,7 @@ selenium:
 
 commands:
   drupal:site-setup:
-    - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/oe_contact_forms" }
+    - { task: "run", command: "drupal:symlink-project" }
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
     - { task: "run", command: "setup:phpunit" }

--- a/src/Form/ContactMessageForm.php
+++ b/src/Form/ContactMessageForm.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_contact_forms\Form;
 
+use Drupal;
 use Drupal\contact\MessageForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -85,7 +86,7 @@ class ContactMessageForm extends MessageForm {
       $mail_view = $this->entityTypeManager
         ->getViewBuilder('contact_message')
         ->view($message, 'mail');
-      $reply .= "\n" . \Drupal::service('renderer')->renderPlain($mail_view);
+      $reply .= "\n" . Drupal::service('renderer')->renderPlain($mail_view);
       $contact_form->setReply($reply);
     }
 

--- a/tests/src/FunctionalJavascript/CorporateContactFormTest.php
+++ b/tests/src/FunctionalJavascript/CorporateContactFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_contact_forms\FunctionalJavascript;
 
+use Drupal;
 use Drupal\contact\Entity\ContactForm;
 use Drupal\contact\Entity\Message;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
@@ -124,11 +125,11 @@ class CorporateContactFormTest extends WebDriverTestBase {
 
     // Assert CSV output with selected columns.
     /* @var \Drupal\file\FileInterface[] $files */
-    $files = \Drupal::entityTypeManager()
+    $files = Drupal::entityTypeManager()
       ->getStorage('file')
       ->loadByProperties(['filename' => 'contact-storage-export.csv']);
     $file = reset($files);
-    $absolute_path = \Drupal::service('file_system')->realpath($file->getFileUri());
+    $absolute_path = Drupal::service('file_system')->realpath($file->getFileUri());
     $actual = file_get_contents($absolute_path);
 
     $headers = '"Message ID",Language,"Form ID","The sender\'s name","The sender\'s email",Subject,Message,Copy,"Recipient ID",Created,"User ID","Country of residence",Phone,Topic';
@@ -539,7 +540,7 @@ class CorporateContactFormTest extends WebDriverTestBase {
    */
   protected function checkCorporateFieldsInStorage($max_delta = 1): void {
     /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $entity_storage */
-    $entity_storage = \Drupal::entityTypeManager()->getStorage('contact_form');
+    $entity_storage = Drupal::entityTypeManager()->getStorage('contact_form');
     /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $entity_storage->load('oe_corporate_form');
     $this->assertNotEmpty($contact_form);
@@ -573,7 +574,7 @@ class CorporateContactFormTest extends WebDriverTestBase {
    */
   protected function checkCorporateFieldsNotInStorage(): void {
     /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $entity_storage */
-    $entity_storage = \Drupal::entityTypeManager()->getStorage('contact_form');
+    $entity_storage = Drupal::entityTypeManager()->getStorage('contact_form');
     /** @var \Drupal\contact\ContactFormInterface $contact_form */
     $contact_form = $entity_storage->load('oe_corporate_form');
     $this->assertNotEmpty($contact_form);

--- a/tests/src/FunctionalJavascript/MessageFormTest.php
+++ b/tests/src/FunctionalJavascript/MessageFormTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\oe_contact_forms\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\contact\Entity\ContactForm;
-use Drupal\Component\Utility\Unicode;
 use Drupal\Core\Test\AssertMailTrait;
 use Drupal\node\Entity\Node;
 use Drupal\Tests\sparql_entity_storage\Traits\SparqlConnectionTrait;
@@ -116,13 +115,13 @@ class MessageFormTest extends WebDriverTestBase {
     // TODO: is there a better method for this ?
     $html = $elements['0']->getOuterHtml();
     $i = [];
-    $i['name'] = Unicode::strpos($html, 'edit-name');
-    $i['email'] = Unicode::strpos($html, 'edit-mail');
-    $i['subject'] = Unicode::strpos($html, 'edit-subject-0-value');
-    $i['message'] = Unicode::strpos($html, 'edit-message-0-value');
-    $i['topic'] = Unicode::strpos($html, 'edit-oe-topic');
-    $i['country'] = Unicode::strpos($html, 'edit-oe-country-residence');
-    $i['privacy'] = Unicode::strpos($html, 'edit-privacy-policy');
+    $i['name'] = mb_strpos($html, 'edit-name');
+    $i['email'] = mb_strpos($html, 'edit-mail');
+    $i['subject'] = mb_strpos($html, 'edit-subject-0-value');
+    $i['message'] = mb_strpos($html, 'edit-message-0-value');
+    $i['topic'] = mb_strpos($html, 'edit-oe-topic');
+    $i['country'] = mb_strpos($html, 'edit-oe-country-residence');
+    $i['privacy'] = mb_strpos($html, 'edit-privacy-policy');
 
     $this->assertTrue($i['name'] < $i['email']);
     $this->assertTrue($i['email'] < $i['subject']);

--- a/tests/src/Kernel/BaseFieldTest.php
+++ b/tests/src/Kernel/BaseFieldTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_contact_forms\Kernel;
 
+use Drupal;
 use Drupal\contact\Entity\ContactForm;
 use Drupal\contact\Entity\Message;
 
@@ -52,7 +53,7 @@ class BaseFieldTest extends ContactFormTestBase {
     $message->save();
 
     /** @var \Drupal\Core\Entity\Sql\SqlContentEntityStorage $entity_type_manager */
-    $entity_type_manager = \Drupal::entityTypeManager()->getStorage('contact_message');
+    $entity_type_manager = Drupal::entityTypeManager()->getStorage('contact_message');
     $entity_type_manager->resetCache();
     /** @var \Drupal\contact\Entity\Message $message */
     $message = $entity_type_manager->load($message->id());
@@ -85,7 +86,7 @@ class BaseFieldTest extends ContactFormTestBase {
     $message = Message::create($data);
     $message->save();
 
-    $form = \Drupal::service('entity.form_builder')->getForm($message, 'default');
+    $form = Drupal::service('entity.form_builder')->getForm($message, 'default');
 
     $this->assertEquals(FALSE, $form['oe_country_residence']['#access'], 'Check that country is not available.');
     $this->assertEquals(FALSE, $form['oe_telephone']['#access'], 'Check that telephone is not available.');


### PR DESCRIPTION
## OPENEUROPA-OEL-164

### Description

Drupal 9 compatibility fixes

### Change log

- Added: core version 8 || 9, other additions
- Changed: "short" import classes, minor code refactor from phpcs report
- Deprecated:
- Removed: PHP 7.2
- Fixed: 
- Security: 

### Commands

```sh
[Insert commands here]

```

