### PR TITLE
EWPP-2035: Fix xdebug-handler version until phpmd 2.12 is released.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "composer/xdebug-handler": "^2.0",
         "drupal/core": "^9.2",
         "drupal/contact_storage": "^1.1",
         "drupal/contact_storage_export": "^1.14",
@@ -31,7 +32,8 @@
     "_readme": [
         "Explicit requirement for egulias/email-validator due to https://www.drupal.org/project/drupal/issues/3061074#comment-14300579. It can be removed when Drupal core 9.2 support is droppped.",
         "Explicit requirement for drupal/csv_serialization version due to its dependency compatibility league/csv with PHP7.4",
-        "Explicit requirement for drupal/token version due to its dependency compatibility with Drupal9."
+        "Explicit requirement for drupal/token version due to its dependency compatibility with Drupal9.",
+        "Requiring composer/xdebug-handler until PHPMD 2.12 is released."
     ],
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",


### PR DESCRIPTION
## EWPP

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

